### PR TITLE
feat: add tags and search

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -63,7 +63,8 @@ mongoose.connect(dbUrl, { useNewUrlParser: true, useUnifiedTopology: true })
 app.get('/api/items', async (req, res) => {
   try {
     const userId = req.query.userId || 'user1';
-    const items = await todoService.getItems(userId);
+    const tag = req.query.tag;
+    const items = await todoService.getItems(userId, tag);
     res.json(items);
   } catch (err) {
     res.status(500).json({ error: err.message });

--- a/server/todoService.js
+++ b/server/todoService.js
@@ -13,6 +13,7 @@ const itemSchema = new mongoose.Schema({
   priority: String, // for task/goal
   dueDate: Date,
   comments: [commentSchema], // for task/goal
+  tags: [String],
   recurrence: {
     frequency: String,
     isRecurring: Boolean,
@@ -22,8 +23,12 @@ const itemSchema = new mongoose.Schema({
 
 const TodoItem = mongoose.models.TodoItem || mongoose.model('TodoItem', itemSchema);
 
-async function getItems(userId) {
-  return TodoItem.find({ userId }).sort({ createdAt: -1 });
+async function getItems(userId, tag) {
+  const filter = { userId };
+  if (tag) {
+    filter.tags = tag;
+  }
+  return TodoItem.find(filter).sort({ createdAt: -1 });
 }
 
 async function createItem(data) {


### PR DESCRIPTION
## Summary
- add tag array to todo schema and allow filtering by tag in API
- support tags in todo UI with entry, display, and tag-based search

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 37 errors, 7 warnings)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68905fcfa450833192e2adbbf759d06a