### PR TITLE
feat: support org-specific onboarding flows

### DIFF
--- a/server/onboardingFlow.json
+++ b/server/onboardingFlow.json
@@ -1,78 +1,80 @@
 {
-  "id": "onboarding-root",
-  "title": "Onboarding Home",
-  "type": "flow",
-  "children": [
-    {
-      "id": "welcome",
-      "title": "Welcome & Introduction",
-      "type": "flow",
-      "children": [
-        {
-          "id": "welcome-1",
-          "title": "Welcome to Our Team!",
-          "type": "card",
-          "content": "We're excited to have you join us. This onboarding journey will help you get familiar with our company culture, policies, and your new role.",
-          "buttons": [
-            { "label": "Next", "action": "goto", "target": "welcome-2" }
-          ]
-        },
-        {
-          "id": "welcome-2",
-          "title": "What to Expect",
-          "type": "card",
-          "content": "Over the next few modules, you'll learn about our company values, meet your team members, understand our policies, and explore your benefits.",
-          "buttons": [
-            { "label": "Next", "action": "goto", "target": "welcome-3" }
-          ]
-        },
-        {
-          "id": "welcome-3",
-          "title": "Your Success Matters",
-          "type": "card",
-          "content": "We believe that a well-onboarded employee is a successful employee. Take your time with each module, ask questions, and don't hesitate to reach out to your manager or HR team.",
-          "buttons": [
-            { "label": "Next", "action": "goto", "target": "welcome-4" }
-          ]
-        },
-        {
-          "id": "welcome-4",
-          "title": "Ready to Begin?",
-          "type": "card",
-          "content": "You're all set to start your onboarding journey! Click 'Complete Welcome' to move on to the next module and continue your progress.",
-          "buttons": [
-            { "label": "Complete Welcome", "action": "goto", "target": "policies" }
-          ]
+  "org1": {
+    "id": "onboarding-root",
+    "title": "Onboarding Home",
+    "type": "flow",
+    "children": [
+      {
+        "id": "welcome",
+        "title": "Welcome & Introduction",
+        "type": "flow",
+        "children": [
+          {
+            "id": "welcome-1",
+            "title": "Welcome to Our Team!",
+            "type": "card",
+            "content": "We're excited to have you join us. This onboarding journey will help you get familiar with our company culture, policies, and your new role.",
+            "buttons": [
+              { "label": "Next", "action": "goto", "target": "welcome-2" }
+            ]
+          },
+          {
+            "id": "welcome-2",
+            "title": "What to Expect",
+            "type": "card",
+            "content": "Over the next few modules, you'll learn about our company values, meet your team members, understand our policies, and explore your benefits.",
+            "buttons": [
+              { "label": "Next", "action": "goto", "target": "welcome-3" }
+            ]
+          },
+          {
+            "id": "welcome-3",
+            "title": "Your Success Matters",
+            "type": "card",
+            "content": "We believe that a well-onboarded employee is a successful employee. Take your time with each module, ask questions, and don't hesitate to reach out to your manager or HR team.",
+            "buttons": [
+              { "label": "Next", "action": "goto", "target": "welcome-4" }
+            ]
+          },
+          {
+            "id": "welcome-4",
+            "title": "Ready to Begin?",
+            "type": "card",
+            "content": "You're all set to start your onboarding journey! Click 'Complete Welcome' to move on to the next module and continue your progress.",
+            "buttons": [
+              { "label": "Complete Welcome", "action": "goto", "target": "policies" }
+            ]
+          }
+        ],
+        "static": {
+          "whatsComingNext": ["Company Policies", "Meet Your Team"]
         }
-      ],
-      "static": {
-        "whatsComingNext": ["Company Policies", "Meet Your Team"]
+      },
+      {
+        "id": "policies",
+        "title": "Company Policies",
+        "type": "flow",
+        "children": [
+          {
+            "id": "policy-handbook",
+            "title": "Employee Handbook",
+            "type": "card",
+            "content": "Our employee handbook covers all aspects of working at our company, including workplace conduct, dress code, attendance policies, and more.",
+            "buttons": [
+              { "label": "Acknowledge", "action": "acknowledge" }
+            ]
+          },
+          {
+            "id": "policy-code-of-conduct",
+            "title": "Code of Conduct",
+            "type": "card",
+            "content": "Our code of conduct establishes the standards of behavior expected from all employees. This includes professional conduct, conflict of interest policies, confidentiality requirements, and anti-harassment guidelines.",
+            "buttons": [
+              { "label": "Acknowledge", "action": "acknowledge" }
+            ]
+          }
+        ]
       }
-    },
-    {
-      "id": "policies",
-      "title": "Company Policies",
-      "type": "flow",
-      "children": [
-        {
-          "id": "policy-handbook",
-          "title": "Employee Handbook",
-          "type": "card",
-          "content": "Our employee handbook covers all aspects of working at our company, including workplace conduct, dress code, attendance policies, and more.",
-          "buttons": [
-            { "label": "Acknowledge", "action": "acknowledge" }
-          ]
-        },
-        {
-          "id": "policy-code-of-conduct",
-          "title": "Code of Conduct",
-          "type": "card",
-          "content": "Our code of conduct establishes the standards of behavior expected from all employees. This includes professional conduct, conflict of interest policies, confidentiality requirements, and anti-harassment guidelines.",
-          "buttons": [
-            { "label": "Acknowledge", "action": "acknowledge" }
-          ]
-        }
-      ]
-    }
-  ]
-} 
+    ]
+  }
+}

--- a/server/onboardingService.js
+++ b/server/onboardingService.js
@@ -1,0 +1,56 @@
+const mongoose = require('mongoose');
+
+const onboardingFlowSchema = new mongoose.Schema({
+  orgId: { type: String, required: true, unique: true },
+  flow: { type: Object, required: true },
+});
+
+const OnboardingFlow =
+  mongoose.models.OnboardingFlow ||
+  mongoose.model('OnboardingFlow', onboardingFlowSchema);
+
+const onboardingUserStateSchema = new mongoose.Schema({
+  orgId: { type: String, required: true },
+  userId: { type: String, required: true },
+  state: { type: Object, required: true },
+});
+
+onboardingUserStateSchema.index({ orgId: 1, userId: 1 }, { unique: true });
+
+const OnboardingUserState =
+  mongoose.models.OnboardingUserState ||
+  mongoose.model('OnboardingUserState', onboardingUserStateSchema);
+
+async function getFlow(orgId) {
+  return OnboardingFlow.findOne({ orgId });
+}
+
+async function saveFlow(orgId, flow) {
+  return OnboardingFlow.findOneAndUpdate(
+    { orgId },
+    { flow },
+    { upsert: true, new: true, setDefaultsOnInsert: true }
+  );
+}
+
+async function getUserState(orgId, userId) {
+  return OnboardingUserState.findOne({ orgId, userId });
+}
+
+async function saveUserState(orgId, userId, state) {
+  return OnboardingUserState.findOneAndUpdate(
+    { orgId, userId },
+    { state },
+    { upsert: true, new: true, setDefaultsOnInsert: true }
+  );
+}
+
+module.exports = {
+  getFlow,
+  saveFlow,
+  getUserState,
+  saveUserState,
+  OnboardingFlow,
+  OnboardingUserState,
+};
+

--- a/server/onboardingUserStates.json
+++ b/server/onboardingUserStates.json
@@ -1,11 +1,13 @@
 {
-  "user1": {
-    "userId": "user1",
-    "currentNodeId": "welcome-2",
-    "progress": {
-      "welcome": 50,
-      "policies": 0
-    },
-    "completedNodes": ["welcome-1"]
+  "org1": {
+    "user1": {
+      "userId": "user1",
+      "currentNodeId": "welcome-2",
+      "progress": {
+        "welcome": 50,
+        "policies": 0
+      },
+      "completedNodes": ["welcome-1"]
+    }
   }
-} 
+}

--- a/src/components/OnboardingDynamic.tsx
+++ b/src/components/OnboardingDynamic.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import flowJson from "@/lib/onboardingFlow.json";
 import { useOnboardingUserState } from "./OnboardingUserState";
 import { Button } from "@/components/ui/button";
 import Navigation from "@/components/Navigation";
@@ -25,6 +24,8 @@ function findNodeById(node: FlowNode, id: string): FlowNode | null {
   return null;
 }
 
+const ORG_ID = "org1";
+
 export default function OnboardingDynamic({ userId = "user1" }: { userId?: string }) {
   const [flow, setFlow] = useState<FlowNode | null>(null);
   const [flowLoading, setFlowLoading] = useState(true);
@@ -34,7 +35,7 @@ export default function OnboardingDynamic({ userId = "user1" }: { userId?: strin
   // Fetch flow from backend
   useEffect(() => {
     setFlowLoading(true);
-    fetch("/api/onboarding-flow")
+    fetch(`/api/orgs/${ORG_ID}/onboarding-flow`)
       .then(r => r.json())
       .then(data => { setFlow(data); setFlowLoading(false); })
       .catch(() => setFlowLoading(false));

--- a/src/components/OnboardingFlowEditor.tsx
+++ b/src/components/OnboardingFlowEditor.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect } from "react";
 
+const ORG_ID = "org1";
+
 interface FlowNode {
   id: string;
   title: string;
@@ -51,7 +53,7 @@ export default function OnboardingFlowEditor() {
   // Fetch flow from backend
   useEffect(() => {
     setLoading(true);
-    fetch("/api/onboarding-flow")
+    fetch(`/api/orgs/${ORG_ID}/onboarding-flow`)
       .then(r => r.json())
       .then(data => { setFlow(data); setLoading(false); })
       .catch(e => { setError("Failed to load flow"); setLoading(false); });
@@ -161,7 +163,7 @@ export default function OnboardingFlowEditor() {
   function handleSaveToBackend() {
     if (!flow) return;
     setSaving(true);
-    fetch("/api/onboarding-flow", {
+    fetch(`/api/orgs/${ORG_ID}/onboarding-flow`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(flow)

--- a/src/components/OnboardingUserState.tsx
+++ b/src/components/OnboardingUserState.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 
+const ORG_ID = "org1";
+
 export interface OnboardingUserState {
   userId: string;
   currentNodeId: string;
@@ -14,7 +16,7 @@ export function useOnboardingUserState(userId: string): [OnboardingUserState | n
   // Fetch from backend
   useEffect(() => {
     setLoading(true);
-    fetch(`/api/onboarding-user-state/${userId}`)
+    fetch(`/api/orgs/${ORG_ID}/onboarding-user-state/${userId}`)
       .then(r => r.json())
       .then(data => {
         if (data) setState(data);
@@ -32,7 +34,7 @@ export function useOnboardingUserState(userId: string): [OnboardingUserState | n
     setState(prev => {
       if (!prev) return prev;
       const newState = { ...prev, ...update };
-      fetch(`/api/onboarding-user-state/${userId}`,
+      fetch(`/api/orgs/${ORG_ID}/onboarding-user-state/${userId}`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
- add REST endpoints that store onboarding flows and user states per organisation
- persist flow and user-progress data for default org `org1`
- front-end flow editor and player now load/save flows using org-aware APIs
- seed onboarding data from JSON files into Mongo when missing

## Testing
- `npm run lint` (fails: Unexpected any, A `require()` style import is forbidden)
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68907066e9648331b7ab99fa3fbb0095