### PR TITLE
feat: enhance onboarding flow editor

### DIFF
--- a/src/components/OnboardingDynamic.tsx
+++ b/src/components/OnboardingDynamic.tsx
@@ -3,14 +3,30 @@ import { useOnboardingUserState } from "./OnboardingUserState";
 import { Button } from "@/components/ui/button";
 import Navigation from "@/components/Navigation";
 
+interface ActionDef {
+  id: string;
+  type: string;
+  target?: string;
+  method?: string;
+  headers?: Record<string, string>;
+  dbType?: string;
+  query?: string;
+}
+
+interface ButtonDef {
+  label: string;
+  actionId?: string;
+}
+
 interface FlowNode {
   id: string;
   title: string;
   type: string;
   children?: FlowNode[];
   content?: string;
-  buttons?: { label: string; action: string; target?: string }[];
-  static?: any;
+  actions?: ActionDef[];
+  buttons?: ButtonDef[];
+  static?: unknown;
 }
 
 function findNodeById(node: FlowNode, id: string): FlowNode | null {
@@ -47,13 +63,31 @@ export default function OnboardingDynamic({ userId = "user1" }: { userId?: strin
     setCurrentNode(node);
   }, [userState?.currentNodeId, flow, userState]);
 
-  function handleButtonClick(btn: any) {
-    if (!userState) return;
-    if (btn.action === "goto" && btn.target) {
-      setUserState({ currentNodeId: btn.target });
+  function handleButtonClick(btn: ButtonDef) {
+    if (!userState || !currentNode) return;
+    const action = currentNode.actions?.find(a => a.id === btn.actionId);
+    if (!action) return;
+    if (action.type === "goto" && action.target) {
+      setUserState({ currentNodeId: action.target });
       setUserState({ completedNodes: Array.from(new Set([...(userState.completedNodes || []), userState.currentNodeId])) });
-    } else if (btn.action === "acknowledge") {
+    } else if (action.type === "acknowledge") {
       setUserState({ completedNodes: Array.from(new Set([...(userState.completedNodes || []), userState.currentNodeId])) });
+    } else if (action.type === "download" && action.target) {
+      const link = document.createElement("a");
+      link.href = action.target;
+      link.download = "";
+      link.target = "_blank";
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    } else if (action.type === "api" && action.target) {
+      fetch(action.target, { method: action.method || "GET", headers: action.headers }).catch(() => {});
+    } else if (action.type === "db") {
+      fetch("/api/db", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ type: action.dbType, query: action.query })
+      }).catch(() => {});
     }
   }
 

--- a/src/components/OnboardingFlowEditor.tsx
+++ b/src/components/OnboardingFlowEditor.tsx
@@ -2,20 +2,40 @@ import { useState, useEffect } from "react";
 
 const ORG_ID = "org1";
 
+interface ActionDef {
+  id: string;
+  type: string;
+  target?: string;
+  method?: string;
+  headers?: Record<string, string>;
+  dbType?: string;
+  query?: string;
+}
+
+interface ButtonDef {
+  label: string;
+  actionId?: string;
+}
+
 interface FlowNode {
   id: string;
   title: string;
   type: string;
   children?: FlowNode[];
   content?: string;
-  buttons?: { label: string; action: string; target?: string }[];
-  static?: any;
+  actions?: ActionDef[];
+  buttons?: ButtonDef[];
+  static?: unknown;
 }
-
-function renderNode(node: FlowNode, depth = 0, onEdit?: (node: FlowNode, parent?: FlowNode) => void, parent?: FlowNode) {
+function TreeNode({ node, depth, onEdit, parent, collapsed, toggle }:{node:FlowNode; depth?:number; onEdit?:(n:FlowNode,p?:FlowNode)=>void; parent?:FlowNode; collapsed:Set<string>; toggle:(id:string)=>void}){
+  const hasChildren = node.children && node.children.length > 0;
+  const isCollapsed = collapsed.has(node.id);
   return (
-    <div key={node.id} style={{ marginLeft: depth * 24, borderLeft: depth ? '2px solid #eee' : undefined, paddingLeft: 8 }}>
+    <div style={{ marginLeft: depth! * 24, borderLeft: depth ? '2px solid #eee' : undefined, paddingLeft: 8 }}>
       <div className="flex items-center gap-2 mb-1">
+        {hasChildren && (
+          <button className="text-xs w-4" onClick={() => toggle(node.id)}>{isCollapsed ? '+' : '-'}</button>
+        )}
         <span className="font-bold">{node.title}</span>
         <span className="text-xs text-muted-foreground">[{node.type}]</span>
         <button className="text-xs text-blue-600 underline" onClick={() => onEdit && onEdit(node, parent)}>Edit</button>
@@ -31,7 +51,9 @@ function renderNode(node: FlowNode, depth = 0, onEdit?: (node: FlowNode, parent?
       {node.static && (
         <div className="text-xs text-gray-500 mb-1">Static: {JSON.stringify(node.static)}</div>
       )}
-      {node.children && node.children.map(child => renderNode(child, depth + 1, onEdit, node))}
+      {!isCollapsed && node.children && node.children.map(child => (
+        <TreeNode key={child.id} node={child} depth={(depth||0)+1} onEdit={onEdit} parent={node} collapsed={collapsed} toggle={toggle} />
+      ))}
     </div>
   );
 }
@@ -45,10 +67,19 @@ export default function OnboardingFlowEditor() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [editingNode, setEditingNode] = useState<{ node: FlowNode; parent?: FlowNode } | null>(null);
-  const [editForm, setEditForm] = useState<any>(null);
+  const [editForm, setEditForm] = useState<Partial<FlowNode> | null>(null);
   const [showAddChild, setShowAddChild] = useState(false);
   const [showAddSibling, setShowAddSibling] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+
+  function toggleCollapse(id: string) {
+    setCollapsed(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  }
 
   // Fetch flow from backend
   useEffect(() => {
@@ -66,7 +97,7 @@ export default function OnboardingFlowEditor() {
       return true;
     }
     if (tree.children) {
-      for (let child of tree.children) {
+      for (const child of tree.children) {
         if (updateNode(child, nodeId, updater, tree)) return true;
       }
     }
@@ -81,7 +112,7 @@ export default function OnboardingFlowEditor() {
       tree.children.splice(idx, 1);
       return true;
     }
-    for (let child of tree.children) {
+    for (const child of tree.children) {
       if (removeNode(child, nodeId)) return true;
     }
     return false;
@@ -125,8 +156,20 @@ export default function OnboardingFlowEditor() {
       title: "New Node",
       type,
       content: type === "card" ? "" : undefined,
+      actions: type === "card" ? [] : undefined,
+      buttons: type === "card" ? [] : undefined,
       children: type === "flow" ? [] : undefined
     };
+    if (type === "flow") {
+      newNode.children = [{
+        id: `${newNode.id}-card-${Date.now()}`,
+        title: "New Card",
+        type: "card",
+        content: "",
+        actions: [],
+        buttons: []
+      }];
+    }
     const updated = deepClone(flow);
     updateNode(updated, editingNode.node.id, (node) => {
       if (!node.children) node.children = [];
@@ -146,8 +189,20 @@ export default function OnboardingFlowEditor() {
       title: "New Node",
       type,
       content: type === "card" ? "" : undefined,
+      actions: type === "card" ? [] : undefined,
+      buttons: type === "card" ? [] : undefined,
       children: type === "flow" ? [] : undefined
     };
+    if (type === "flow") {
+      newNode.children = [{
+        id: `${newNode.id}-card-${Date.now()}`,
+        title: "New Card",
+        type: "card",
+        content: "",
+        actions: [],
+        buttons: []
+      }];
+    }
     const updated = deepClone(flow);
     updateNode(updated, editingNode.parent.id, (node) => {
       if (!node.children) node.children = [];
@@ -157,6 +212,42 @@ export default function OnboardingFlowEditor() {
     setEditingNode(null);
     setEditForm(null);
     setShowAddSibling(false);
+  }
+
+  function handleActionChange(index: number, field: keyof ActionDef, value: unknown) {
+    const actions = editForm.actions ? [...editForm.actions] : [];
+    actions[index] = { ...actions[index], [field]: value };
+    setEditForm({ ...editForm, actions });
+  }
+
+  function handleAddAction() {
+    const actions = editForm.actions ? [...editForm.actions] : [];
+    actions.push({ id: `action-${Date.now()}`, type: "goto", target: "" });
+    setEditForm({ ...editForm, actions });
+  }
+
+  function handleRemoveAction(index: number) {
+    const actions = editForm.actions ? [...editForm.actions] : [];
+    actions.splice(index, 1);
+    setEditForm({ ...editForm, actions });
+  }
+
+  function handleButtonChange(index: number, field: keyof ButtonDef, value: unknown) {
+    const buttons = editForm.buttons ? [...editForm.buttons] : [];
+    buttons[index] = { ...buttons[index], [field]: value };
+    setEditForm({ ...editForm, buttons });
+  }
+
+  function handleAddButton() {
+    const buttons = editForm.buttons ? [...editForm.buttons] : [];
+    buttons.push({ label: "New", actionId: editForm.actions?.[0]?.id });
+    setEditForm({ ...editForm, buttons });
+  }
+
+  function handleRemoveButton(index: number) {
+    const buttons = editForm.buttons ? [...editForm.buttons] : [];
+    buttons.splice(index, 1);
+    setEditForm({ ...editForm, buttons });
   }
 
   // Save to backend
@@ -180,8 +271,8 @@ export default function OnboardingFlowEditor() {
   return (
     <div className="p-6">
       <h2 className="text-2xl font-bold mb-4">Onboarding Flow Editor</h2>
-      <div className="mb-6">
-        {renderNode(flow, 0, handleEdit)}
+      <div className="mb-6 max-h-96 overflow-auto border rounded p-2">
+        <TreeNode node={flow} depth={0} onEdit={handleEdit} collapsed={collapsed} toggle={toggleCollapse} />
       </div>
       <button className="bg-blue-600 text-white px-4 py-2 rounded mb-4" onClick={handleSaveToBackend} disabled={saving}>{saving ? "Saving..." : "Save Flow to Backend"}</button>
       {editingNode && editForm && (
@@ -199,21 +290,68 @@ export default function OnboardingFlowEditor() {
             </select>
           </div>
           {editForm.type === "card" && (
-            <div className="mb-2">
-              <label className="block text-xs mb-1">Content</label>
-              <textarea className="border px-2 py-1 rounded w-full" value={editForm.content || ""} onChange={e => setEditForm({ ...editForm, content: e.target.value })} />
-            </div>
+            <>
+              <div className="mb-2">
+                <label className="block text-xs mb-1">Content</label>
+                <textarea className="border px-2 py-1 rounded w-full" value={editForm.content || ""} onChange={e => setEditForm({ ...editForm, content: e.target.value })} />
+              </div>
+              <div className="mb-2">
+                <label className="block text-xs mb-1">Actions</label>
+                {editForm.actions && editForm.actions.map((act: ActionDef, i: number) => (
+                  <div key={i} className="mb-2 border p-2 rounded">
+                    <div className="flex gap-2 mb-1">
+                      <input className="border px-2 py-1 rounded flex-1" placeholder="Action ID" value={act.id} onChange={e => handleActionChange(i, "id", e.target.value)} />
+                      <select className="border px-2 py-1 rounded" value={act.type} onChange={e => handleActionChange(i, "type", e.target.value)}>
+                        <option value="goto">goto</option>
+                        <option value="acknowledge">acknowledge</option>
+                        <option value="download">download</option>
+                        <option value="api">api</option>
+                        <option value="db">db</option>
+                      </select>
+                      <button className="text-red-600 text-xs" onClick={() => handleRemoveAction(i)}>Delete</button>
+                    </div>
+                    {(act.type === "goto" || act.type === "download" || act.type === "api") && (
+                      <input className="border px-2 py-1 rounded w-full mb-1" placeholder={act.type === "goto" ? "Target node id" : "URL"} value={act.target || ""} onChange={e => handleActionChange(i, "target", e.target.value)} />
+                    )}
+                    {act.type === "api" && (
+                      <textarea className="border px-2 py-1 rounded w-full mb-1" placeholder="Headers JSON" value={JSON.stringify(act.headers || {}, null, 2)} onChange={e => {
+                        try { handleActionChange(i, "headers", JSON.parse(e.target.value)); } catch { handleActionChange(i, "headers", {}); }
+                      }} />
+                    )}
+                    {act.type === "db" && (
+                      <div className="flex flex-col gap-1">
+                        <select className="border px-2 py-1 rounded" value={act.dbType || "mongo"} onChange={e => handleActionChange(i, "dbType", e.target.value)}>
+                          <option value="mongo">mongo</option>
+                          <option value="postgres">postgres</option>
+                          <option value="mysql">mysql</option>
+                        </select>
+                        <textarea className="border px-2 py-1 rounded w-full" placeholder="Query" value={act.query || ""} onChange={e => handleActionChange(i, "query", e.target.value)} />
+                      </div>
+                    )}
+                  </div>
+                ))}
+                <button className="bg-purple-600 text-white px-2 py-1 rounded" onClick={handleAddAction}>Add Action</button>
+              </div>
+              <div className="mb-2">
+                <label className="block text-xs mb-1">Buttons</label>
+                {editForm.buttons && editForm.buttons.map((btn: ButtonDef, i: number) => (
+                  <div key={i} className="mb-2 border p-2 rounded">
+                    <div className="flex gap-2 mb-1">
+                      <input className="border px-2 py-1 rounded flex-1" placeholder="Label" value={btn.label} onChange={e => handleButtonChange(i, "label", e.target.value)} />
+                      <select className="border px-2 py-1 rounded" value={btn.actionId || ""} onChange={e => handleButtonChange(i, "actionId", e.target.value)}>
+                        <option value="">--action--</option>
+                        {editForm.actions && editForm.actions.map((act) => (
+                          <option key={act.id} value={act.id}>{act.id}</option>
+                        ))}
+                      </select>
+                      <button className="text-red-600 text-xs" onClick={() => handleRemoveButton(i)}>Delete</button>
+                    </div>
+                  </div>
+                ))}
+                <button className="bg-purple-600 text-white px-2 py-1 rounded" onClick={handleAddButton}>Add Button</button>
+              </div>
+            </>
           )}
-          <div className="mb-2">
-            <label className="block text-xs mb-1">Buttons (JSON)</label>
-            <textarea className="border px-2 py-1 rounded w-full" value={editForm.buttons ? JSON.stringify(editForm.buttons, null, 2) : ""} onChange={e => {
-              try {
-                setEditForm({ ...editForm, buttons: JSON.parse(e.target.value) });
-              } catch {
-                setEditForm({ ...editForm, buttons: e.target.value });
-              }
-            }} />
-          </div>
           <div className="flex gap-2 mt-2">
             <button className="bg-green-600 text-white px-3 py-1 rounded" onClick={handleSaveEdit}>Save</button>
             <button className="bg-red-600 text-white px-3 py-1 rounded" onClick={handleRemoveNode}>Delete</button>


### PR DESCRIPTION
## Summary
- add collapsible, scrollable tree view for onboarding flow editing
- support editing card actions including downloads, API calls, and DB queries
- handle download, API and DB actions in dynamic onboarding runtime
- define actions separately from card buttons and link buttons by action id

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Unexpected any etc.)


------
https://chatgpt.com/codex/tasks/task_e_68907f03062c8331b8621be74fd25678