### PR TITLE
feat: add kanban board view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import Benefits from "./pages/onboarding/Benefits";
 import Checklist from "./pages/onboarding/Checklist";
 import FlowEditorPage from "./pages/onboarding/FlowEditor";
 import OnboardingDynamicPage from "./pages/onboarding/Dynamic";
+import KanbanPage from "./pages/Kanban";
 
 const queryClient = new QueryClient();
 
@@ -40,6 +41,7 @@ const App = () => (
           <Route path="/onboarding/checklist" element={<Checklist />} />
           <Route path="/onboarding/flow-editor" element={<FlowEditorPage />} />
           <Route path="/onboarding/dynamic" element={<OnboardingDynamicPage />} />
+          <Route path="/kanban" element={<KanbanPage />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -1,0 +1,63 @@
+import { Card } from "@/components/ui/card";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { useMemo } from "react";
+
+export type TodoStatus = "todo" | "in-progress" | "completed" | "on-hold";
+export type ItemCategory = "task" | "reminder" | "goal";
+
+interface TodoItem {
+  _id?: string;
+  text: string;
+  category: ItemCategory;
+  status?: TodoStatus;
+}
+
+interface KanbanBoardProps {
+  items: TodoItem[];
+  onStatusChange: (id: string, status: TodoStatus) => void;
+}
+
+const columns: { key: TodoStatus; title: string }[] = [
+  { key: "todo", title: "To Do" },
+  { key: "in-progress", title: "In Progress" },
+  { key: "on-hold", title: "On Hold" },
+  { key: "completed", title: "Completed" },
+];
+
+export default function KanbanBoard({ items, onStatusChange }: KanbanBoardProps) {
+  const groups = useMemo(() => {
+    return columns.map(col => ({
+      ...col,
+      items: items.filter(i => (i.status ?? "todo") === col.key),
+    }));
+  }, [items]);
+
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
+      {groups.map(col => (
+        <div key={col.key} className="space-y-2">
+          <h3 className="text-lg font-semibold">{col.title}</h3>
+          {col.items.map(item => (
+            <Card key={item._id} className="p-2 space-y-2 bg-card">
+              <div className="font-medium">{item.text}</div>
+              <Select
+                value={item.status ?? "todo"}
+                onValueChange={v => item._id && onStatusChange(item._id, v as TodoStatus)}
+              >
+                <SelectTrigger className="h-8 text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="todo">Todo</SelectItem>
+                  <SelectItem value="in-progress">In Progress</SelectItem>
+                  <SelectItem value="on-hold">On Hold</SelectItem>
+                  <SelectItem value="completed">Completed</SelectItem>
+                </SelectContent>
+              </Select>
+            </Card>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,12 +1,13 @@
 import { NavLink } from "react-router-dom";
 import { Button } from "@/components/ui/button";
-import { Home, BarChart3, Settings, Info, GraduationCap } from "lucide-react";
+import { Home, BarChart3, Settings, Info, GraduationCap, KanbanSquare } from "lucide-react";
 
 export default function Navigation() {
   const navItems = [
     { to: "/", icon: Home, label: "Home" },
     { to: "/onboarding", icon: GraduationCap, label: "Onboarding" },
     { to: "/statistics", icon: BarChart3, label: "Statistics" },
+    { to: "/kanban", icon: KanbanSquare, label: "Kanban" },
     { to: "/settings", icon: Settings, label: "Settings" },
     { to: "/about", icon: Info, label: "About" },
   ];

--- a/src/pages/Kanban.tsx
+++ b/src/pages/Kanban.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useState } from "react";
+import Navigation from "@/components/Navigation";
+import KanbanBoard, { TodoStatus } from "@/components/KanbanBoard";
+
+interface TodoItem {
+  _id?: string;
+  text: string;
+  category: "task" | "reminder" | "goal";
+  status?: TodoStatus;
+  dueDate?: Date;
+  createdAt?: Date;
+  [key: string]: unknown;
+}
+
+interface RawItem extends Omit<TodoItem, "dueDate" | "createdAt"> {
+  dueDate?: string;
+  createdAt?: string;
+}
+
+const parseDates = (item: RawItem): TodoItem => ({
+  ...item,
+  createdAt: item.createdAt ? new Date(item.createdAt) : undefined,
+  dueDate: item.dueDate ? new Date(item.dueDate) : undefined,
+});
+
+const KanbanPage = () => {
+  const [items, setItems] = useState<TodoItem[]>([]);
+
+  const fetchItems = async () => {
+    const res = await fetch("/api/items?userId=user1");
+    const data = await res.json();
+    setItems(data.map(parseDates));
+  };
+
+  useEffect(() => {
+    fetchItems();
+  }, []);
+
+  const updateStatus = async (id: string, status: TodoStatus) => {
+    const item = items.find(i => i._id === id);
+    if (!item) return;
+    const res = await fetch(`/api/items/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ...item, status }),
+    });
+    const updated = await res.json();
+    setItems(prev => prev.map(i => (i._id === id ? parseDates(updated) : i)));
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-background to-accent/20">
+      <Navigation />
+      <div className="p-4 max-w-6xl mx-auto">
+        <h1 className="text-2xl font-bold mb-4">Kanban Board</h1>
+        <KanbanBoard items={items} onStatusChange={updateStatus} />
+      </div>
+    </div>
+  );
+};
+
+export default KanbanPage;


### PR DESCRIPTION
## Summary
- add KanbanBoard component for status-based task management
- expose Kanban page and navigation link
- wire up routing for new Kanban board view

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any, @typescript-eslint/no-require-imports)*
- `npx eslint src/components/KanbanBoard.tsx src/pages/Kanban.tsx src/components/Navigation.tsx src/App.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890851b37d48331b8d5a2f719a6da90