### PR TITLE
feat: add draggable kanban board

### DIFF
--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -1,5 +1,6 @@
 import { Card } from "@/components/ui/card";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { useMemo } from "react";
 
 export type TodoStatus = "todo" | "in-progress" | "completed" | "on-hold";
@@ -10,6 +11,7 @@ interface TodoItem {
   text: string;
   category: ItemCategory;
   status?: TodoStatus;
+  comments?: { text: string; createdAt?: Date }[];
 }
 
 interface KanbanBoardProps {
@@ -32,13 +34,33 @@ export default function KanbanBoard({ items, onStatusChange }: KanbanBoardProps)
     }));
   }, [items]);
 
+  const handleDragStart = (e: React.DragEvent<HTMLDivElement>, id: string) => {
+    e.dataTransfer.setData("text/plain", id);
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>, status: TodoStatus) => {
+    e.preventDefault();
+    const id = e.dataTransfer.getData("text/plain");
+    if (id) onStatusChange(id, status);
+  };
+
   return (
-    <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
+    <div className="flex gap-4 overflow-x-auto">
       {groups.map(col => (
-        <div key={col.key} className="space-y-2">
+        <div
+          key={col.key}
+          className="space-y-2 w-72 flex-shrink-0"
+          onDragOver={e => e.preventDefault()}
+          onDrop={e => handleDrop(e, col.key)}
+        >
           <h3 className="text-lg font-semibold">{col.title}</h3>
           {col.items.map(item => (
-            <Card key={item._id} className="p-2 space-y-2 bg-card">
+            <Card
+              key={item._id}
+              className="p-2 space-y-2 bg-card"
+              draggable
+              onDragStart={e => item._id && handleDragStart(e, item._id)}
+            >
               <div className="font-medium">{item.text}</div>
               <Select
                 value={item.status ?? "todo"}
@@ -54,6 +76,22 @@ export default function KanbanBoard({ items, onStatusChange }: KanbanBoardProps)
                   <SelectItem value="completed">Completed</SelectItem>
                 </SelectContent>
               </Select>
+              <Collapsible>
+                <CollapsibleTrigger className="text-xs text-muted-foreground underline">
+                  Comments ({item.comments?.length ?? 0})
+                </CollapsibleTrigger>
+                <CollapsibleContent className="mt-1 space-y-1">
+                  {item.comments && item.comments.length > 0 ? (
+                    item.comments.map((c, idx) => (
+                      <div key={idx} className="text-xs text-muted-foreground">
+                        {c.text}
+                      </div>
+                    ))
+                  ) : (
+                    <div className="text-xs text-muted-foreground">No comments</div>
+                  )}
+                </CollapsibleContent>
+              </Collapsible>
             </Card>
           ))}
         </div>

--- a/src/pages/Kanban.tsx
+++ b/src/pages/Kanban.tsx
@@ -9,18 +9,27 @@ interface TodoItem {
   status?: TodoStatus;
   dueDate?: Date;
   createdAt?: Date;
+  comments?: { text: string; createdAt?: Date }[];
   [key: string]: unknown;
 }
 
-interface RawItem extends Omit<TodoItem, "dueDate" | "createdAt"> {
+interface RawItem
+  extends Omit<TodoItem, "dueDate" | "createdAt" | "comments"> {
   dueDate?: string;
   createdAt?: string;
+  comments?: { text: string; createdAt?: string }[];
 }
 
 const parseDates = (item: RawItem): TodoItem => ({
   ...item,
   createdAt: item.createdAt ? new Date(item.createdAt) : undefined,
   dueDate: item.dueDate ? new Date(item.dueDate) : undefined,
+  comments: item.comments
+    ? item.comments.map(c => ({
+        ...c,
+        createdAt: c.createdAt ? new Date(c.createdAt) : undefined,
+      }))
+    : [],
 });
 
 const KanbanPage = () => {


### PR DESCRIPTION
## Summary
- add drag and drop support for Kanban cards
- show item comments inside collapsible panels
- parse comments from API for Kanban items

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: multiple existing lint errors)*
- `npx eslint src/components/KanbanBoard.tsx src/pages/Kanban.tsx && echo 'eslint passed'`


------
https://chatgpt.com/codex/tasks/task_e_6890e918acf08331b9b9928d91948e14